### PR TITLE
Moved update interval to end of loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,10 +15,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // The global path to the bpftool binary

--- a/ui/explorer.go
+++ b/ui/explorer.go
@@ -197,6 +197,7 @@ func updateBpfPrograms() {
 			}
 		}
 	}
+
 	enrichPrograms()
 	lock.Unlock()
 }
@@ -216,8 +217,6 @@ func NewBpfExplorerView(t *Tui) *BpfExplorerView {
 
 func (b *BpfExplorerView) Update() {
 	for {
-		time.Sleep(3 * time.Second)
-		updateBpfPrograms()
 		currentSelection := b.programList.GetCurrentItem()
 
 		tui.App.QueueUpdateDraw(func() {
@@ -226,6 +225,8 @@ func (b *BpfExplorerView) Update() {
 			populateList(b.programList)
 			b.programList.SetCurrentItem(currentSelection)
 		})
+		time.Sleep(3 * time.Second)
+		updateBpfPrograms()
 	}
 }
 


### PR DESCRIPTION
The loading of bpf programs was slow because the update sleep timer went before drawing to the TUI. Since all the data was already collected we didn't need to wait to draw the UI 